### PR TITLE
Add support for lakeFS 

### DIFF
--- a/action/format.go
+++ b/action/format.go
@@ -1,6 +1,6 @@
 package action
 
 type Format struct {
-	Proviver string            `json:"provider,omitempty"`
-	Options  map[string]string `json:"options,omitempty"`
+	Proviver string            `json:"provider"`
+	Options  map[string]string `json:"options"`
 }

--- a/action/metadata.go
+++ b/action/metadata.go
@@ -11,14 +11,14 @@ import (
 )
 
 type Metadata struct {
-	ID               string            `json:"id,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Description      string            `json:"description,omitempty"`
-	Format           Format            `json:"format,omitempty"`
-	SchemaString     string            `json:"schemaString,omitempty"`
-	PartitionColumns []string          `json:"partitionColumns,omitempty"`
-	Configuration    map[string]string `json:"configuration,omitempty"`
-	CreatedTime      *int64            `json:"createdTime,omitempty"`
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	Description      string            `json:"description"`
+	Format           Format            `json:"format"`
+	SchemaString     string            `json:"schemaString"`
+	PartitionColumns []string          `json:"partitionColumns"`
+	Configuration    map[string]string `json:"configuration"`
+	CreatedTime      *int64            `json:"createdTime"`
 }
 
 func DefaultMetadata() *Metadata {

--- a/internal/util/path/path.go
+++ b/internal/util/path/path.go
@@ -66,6 +66,19 @@ func ConvertToBlobURL(urlstr string) (string, error) {
 		}
 		u.RawQuery = q
 		return u.String(), nil
+	} else {
+		storage, prefix, found := strings.Cut(u.Path, "/")
+		u.Path = storage
+		// set prefix
+		if found {
+			v.Set("prefix", prefix)
+		}
+		q, err := url.QueryUnescape(v.Encode())
+		if err != nil {
+			return "", eris.Wrap(err, "")
+		}
+		u.RawQuery = q
+		return u.String(), nil
 	}
 
 	return "", eris.New("not supported scheme" + u.Scheme)

--- a/internal/util/path/s3Path.go
+++ b/internal/util/path/s3Path.go
@@ -1,0 +1,1 @@
+package path

--- a/internal/util/path/s3Path.go
+++ b/internal/util/path/s3Path.go
@@ -1,1 +1,0 @@
-package path

--- a/log_test.go
+++ b/log_test.go
@@ -909,7 +909,7 @@ func TestLog_schema_must_contain_all_partition_columns(t *testing.T) {
 
 	schema := types.NewStructType([]*types.StructField{
 		types.NewStructField("a", &types.StringType{}, true),
-		types.NewStructField("b", &types.LongType{}, true),
+		types.NewStructField("b", &types.BigIntType{}, true),
 		types.NewStructField("foo", &types.IntegerType{}, true),
 		types.NewStructField("bar", &types.BooleanType{}, true),
 	})
@@ -965,7 +965,7 @@ func TestLog_schema_contains_no_data_columns_and_only_partition_columns(t *testi
 
 			schema := types.NewStructType([]*types.StructField{
 				types.NewStructField("part_1", &types.StringType{}, true),
-				types.NewStructField("part_2", &types.LongType{}, true),
+				types.NewStructField("part_2", &types.BigIntType{}, true),
 			})
 			schemaString, err := types.ToJSON(schema)
 			assert.NoError(t, err)

--- a/record.go
+++ b/record.go
@@ -52,8 +52,16 @@ func (p *PartitionRowRecord) GetInt(fieldName string) (int, error) {
 	return strconv.Atoi(v)
 }
 
-func (p *PartitionRowRecord) GetInt64(fieldName string) (int64, error) {
-	v, err := checkPrimitiveField[*types.LongType](p, fieldName, "long")
+func (p *PartitionRowRecord) GetBigInt64(fieldName string) (int64, error) {
+	v, err := checkPrimitiveField[*types.BigIntType](p, fieldName, "bigint")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(v, 10, 64)
+}
+
+func (p *PartitionRowRecord) GetLongInt64(fieldName string) (int64, error) {
+	v, err := checkPrimitiveField[*types.BigIntType](p, fieldName, "long")
 	if err != nil {
 		return 0, err
 	}

--- a/store/s3.go
+++ b/store/s3.go
@@ -2,6 +2,12 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsv2cfg "github.com/aws/aws-sdk-go-v2/config"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	goblob "gocloud.dev/blob"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -10,8 +16,7 @@ import (
 	"github.com/csimplestring/delta-go/iter"
 	"github.com/rotisserie/eris"
 
-	goblob "gocloud.dev/blob"
-	_ "gocloud.dev/blob/s3blob"
+	"gocloud.dev/blob/s3blob"
 )
 
 // Note: currently s3 log store only supports single driver.
@@ -45,6 +50,96 @@ func NewS3LogStore(logDir string) (*S3SingleDriverLogStore, error) {
 		logDir: logDir,
 		s:      s,
 	}, nil
+}
+
+type compatBucketURLOpener struct {
+	cfg      aws.Config
+	awsProps AWSProperties
+}
+
+func (cbuo compatBucketURLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*goblob.Bucket, error) {
+	clientV2 := s3v2.NewFromConfig(cbuo.cfg, func(o *s3v2.Options) {
+		o.BaseEndpoint = aws.String(cbuo.awsProps.Endpoint)
+		o.EndpointOptions.DisableHTTPS = cbuo.awsProps.DisableHTTPs
+		o.UsePathStyle = cbuo.awsProps.ForcePathStyle
+	})
+	return s3blob.OpenBucketV2(ctx, clientV2, u.Host, nil)
+}
+
+func RegisterS3CompatBucketURLOpener(scheme string, awsProps *AWSProperties) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println(r)
+		}
+	}()
+	ctx := context.Background()
+	cfg, _ := GenerateConfig(ctx, awsProps)
+	cbuo := compatBucketURLOpener{
+		cfg:      cfg,
+		awsProps: *awsProps,
+	}
+	goblob.DefaultURLMux().RegisterBucket(scheme, &cbuo)
+}
+
+func NewS3CompatLogStore(awsProps *AWSProperties, bucketName, path string) (*S3SingleDriverLogStore, error) {
+	ctx := context.Background()
+	cfg, err := GenerateConfig(ctx, awsProps)
+	clientV2 := s3v2.NewFromConfig(cfg, func(o *s3v2.Options) {
+		o.BaseEndpoint = aws.String(awsProps.Endpoint)
+		o.EndpointOptions.DisableHTTPS = awsProps.DisableHTTPs
+		o.UsePathStyle = awsProps.ForcePathStyle
+	})
+	bucket, err := s3blob.OpenBucketV2(ctx, clientV2, bucketName, nil)
+	logDir := handleLogDirPath(path)
+	bucket = goblob.PrefixedBucket(bucket, logDir)
+	if err != nil {
+		return nil, err
+	}
+	s := &baseStore{
+		logDir: logDir,
+		bucket: bucket,
+		beforeWriteFn: func(asFunc func(interface{}) bool) error {
+			return nil
+		},
+		writeErrorFn: func(err error, path string) error {
+			return err
+		},
+	}
+
+	return &S3SingleDriverLogStore{
+		logDir: logDir,
+		s:      s,
+	}, nil
+}
+
+func handleLogDirPath(path string) string {
+	if strings.HasSuffix(path, "_delta_log/") {
+		return path
+	} else if strings.HasSuffix(path, "_delta_log") {
+		return path + "/"
+	} else {
+		return path + "/_delta_log/"
+	}
+}
+
+type AWSProperties struct {
+	Region         string
+	ForcePathStyle bool
+	DisableHTTPs   bool
+	CredsProvider  aws.CredentialsProvider
+	Endpoint       string
+}
+
+func GenerateConfig(ctx context.Context, awsProps *AWSProperties) (aws.Config, error) {
+	conf, err := awsv2cfg.LoadDefaultConfig(ctx,
+		awsv2cfg.WithDefaultRegion("us-east-1"),
+		awsv2cfg.WithRegion(awsProps.Region),
+		awsv2cfg.WithCredentialsProvider(awsProps.CredsProvider),
+	)
+	if err != nil {
+		return aws.Config{}, err
+	}
+	return conf, nil
 }
 
 type S3SingleDriverLogStore struct {

--- a/types/expr_binary.go
+++ b/types/expr_binary.go
@@ -73,7 +73,7 @@ func compareWithType(dataType DataType, l any, r any) (int, error) {
 		return primitiveCompare[int](l, r), nil
 	case *FloatType:
 		return primitiveCompare[float32](l, r), nil
-	case *LongType:
+	case *BigIntType, *LongType:
 		return primitiveCompare[int64](l, r), nil
 	case *ByteType:
 		return primitiveCompare[byte](l, r), nil

--- a/types/expr_binary_test.go
+++ b/types/expr_binary_test.go
@@ -65,6 +65,7 @@ func TestComparison(t *testing.T) {
 	inputs := []input{
 		{LiteralInt(1), LiteralInt(2), LiteralInt(1), LiteralNull(&IntegerType{})},
 		{LiteralFloat(1), LiteralFloat(2), LiteralFloat(1), LiteralNull(&FloatType{})},
+		{LiteralBigInt(1), LiteralBigInt(2), LiteralBigInt(1), LiteralNull(&BigIntType{})},
 		{LiteralLong(1), LiteralLong(2), LiteralLong(1), LiteralNull(&LongType{})},
 		{LiteralShort(1), LiteralShort(2), LiteralShort(1), LiteralNull(&ShortType{})},
 		{LiteralDouble(1), LiteralDouble(2), LiteralDouble(1), LiteralNull(&DoubleType{})},

--- a/types/expr_column.go
+++ b/types/expr_column.go
@@ -19,8 +19,10 @@ func NewColumn(name string, t DataType) *Column {
 	switch t.(type) {
 	case *IntegerType:
 		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetInt(name) }
+	case *BigIntType:
+		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetBigInt64(name) }
 	case *LongType:
-		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetInt64(name) }
+		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetLongInt64(name) }
 	case *ByteType:
 		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetByte(name) }
 	case *ShortType:

--- a/types/expr_literal.go
+++ b/types/expr_literal.go
@@ -63,6 +63,10 @@ func LiteralFloat(f float32) *Literal {
 	return &Literal{Value: f, Type: &FloatType{}}
 }
 
+func LiteralBigInt(n int64) *Literal {
+	return &Literal{Value: n, Type: &BigIntType{}}
+}
+
 func LiteralLong(n int64) *Literal {
 	return &Literal{Value: n, Type: &LongType{}}
 }

--- a/types/expr_literal_test.go
+++ b/types/expr_literal_test.go
@@ -17,6 +17,7 @@ func TestLiteral(t *testing.T) {
 	testLiteral(LiteralDouble(float64(1.0)), float64(1.0), t)
 	testLiteral(LiteralInt(5), 5, t)
 	testLiteral(LiteralLong(int64(10)), int64(10), t)
+	testLiteral(LiteralBigInt(int64(10)), int64(10), t)
 
 	testLiteral(LiteralNull(&BooleanType{}), nil, t)
 	testLiteral(LiteralNull(&IntegerType{}), nil, t)

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -13,7 +13,8 @@ type RowRecord interface {
 	IsNullAt(fieldName string) (bool, error)
 
 	GetInt(fieldName string) (int, error)
-	GetInt64(fieldName string) (int64, error)
+	GetBigInt64(fieldName string) (int64, error)
+	GetLongInt64(fieldName string) (int64, error)
 	GetByte(fieldName string) (int8, error)
 	GetShort(fieldName string) (int16, error)
 	GetBoolean(fieldName string) (bool, error)

--- a/types/type_parser.go
+++ b/types/type_parser.go
@@ -11,8 +11,8 @@ import (
 )
 
 var nonDecimalTypes []DataType = []DataType{
-	&BinaryType{}, &BooleanType{}, &ByteType{}, &DateType{}, &DoubleType{},
-	&FloatType{}, &IntegerType{}, &LongType{}, &NullType{}, &ShortType{}, &StringType{}, &TimestampType{},
+	&BinaryType{}, &BooleanType{}, &ByteType{}, &DateType{}, &DoubleType{}, &LongType{},
+	&FloatType{}, &IntegerType{}, &BigIntType{}, &NullType{}, &ShortType{}, &StringType{}, &TimestampType{},
 }
 
 var nonDecimalNameToType map[string]DataType = make(map[string]DataType)

--- a/types/type_parser_test.go
+++ b/types/type_parser_test.go
@@ -63,6 +63,7 @@ func TestDataTypeSerde(t *testing.T) {
 	check(&ByteType{})
 	check(&ShortType{})
 	check(&IntegerType{})
+	check(&BigIntType{})
 	check(&LongType{})
 	check(&FloatType{})
 	check(&DoubleType{})

--- a/types/type_primitives.go
+++ b/types/type_primitives.go
@@ -64,11 +64,18 @@ func (i *IntegerType) Name() string {
 	return "integer"
 }
 
+type BigIntType struct {
+}
+
+func (l *BigIntType) Name() string {
+	return "bigint"
+}
+
 type LongType struct {
 }
 
 func (l *LongType) Name() string {
-	return "bigint"
+	return "long"
 }
 
 type NullType struct {


### PR DESCRIPTION
The following PR includes changes to the `delta-go` library which implements the `Delta Lake` protocol support for Go.

## Changes
- In order to write a Delta Log in JSON format such that it would be a Delta-Lake-validated log, the `omitempty` tags had to be removed.
- Add an option to generate an S3Compatible Log store to communicate with an S3-compatible system's Delta Log.
- Add `EarliestVersion` method to the Delta Snapshot interface so that one can get the earliest version to read from.
- Add a function to register URL openers with S3-compatible schemes (the library uses both a log store and a URL opener to read different entities from the Delta Lake directory, namely the delta log, and the latest checkpoint).
- Add the `ForTableWithStore` that allows reading a table with a given log store, or initialize a new log store if `nil` is provided. This is crucial for the support of the S3-compatible log store implementation.