### PR TITLE
Add support for BigInt

### DIFF
--- a/log_test.go
+++ b/log_test.go
@@ -909,7 +909,7 @@ func TestLog_schema_must_contain_all_partition_columns(t *testing.T) {
 
 	schema := types.NewStructType([]*types.StructField{
 		types.NewStructField("a", &types.StringType{}, true),
-		types.NewStructField("b", &types.LongType{}, true),
+		types.NewStructField("b", &types.BigIntType{}, true),
 		types.NewStructField("foo", &types.IntegerType{}, true),
 		types.NewStructField("bar", &types.BooleanType{}, true),
 	})
@@ -965,7 +965,7 @@ func TestLog_schema_contains_no_data_columns_and_only_partition_columns(t *testi
 
 			schema := types.NewStructType([]*types.StructField{
 				types.NewStructField("part_1", &types.StringType{}, true),
-				types.NewStructField("part_2", &types.LongType{}, true),
+				types.NewStructField("part_2", &types.BigIntType{}, true),
 			})
 			schemaString, err := types.ToJSON(schema)
 			assert.NoError(t, err)

--- a/record.go
+++ b/record.go
@@ -52,8 +52,16 @@ func (p *PartitionRowRecord) GetInt(fieldName string) (int, error) {
 	return strconv.Atoi(v)
 }
 
-func (p *PartitionRowRecord) GetInt64(fieldName string) (int64, error) {
-	v, err := checkPrimitiveField[*types.LongType](p, fieldName, "long")
+func (p *PartitionRowRecord) GetBigInt64(fieldName string) (int64, error) {
+	v, err := checkPrimitiveField[*types.BigIntType](p, fieldName, "bigint")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(v, 10, 64)
+}
+
+func (p *PartitionRowRecord) GetLongInt64(fieldName string) (int64, error) {
+	v, err := checkPrimitiveField[*types.BigIntType](p, fieldName, "long")
 	if err != nil {
 		return 0, err
 	}

--- a/types/expr_binary.go
+++ b/types/expr_binary.go
@@ -73,7 +73,7 @@ func compareWithType(dataType DataType, l any, r any) (int, error) {
 		return primitiveCompare[int](l, r), nil
 	case *FloatType:
 		return primitiveCompare[float32](l, r), nil
-	case *LongType:
+	case *BigIntType, *LongType:
 		return primitiveCompare[int64](l, r), nil
 	case *ByteType:
 		return primitiveCompare[byte](l, r), nil

--- a/types/expr_binary_test.go
+++ b/types/expr_binary_test.go
@@ -65,6 +65,7 @@ func TestComparison(t *testing.T) {
 	inputs := []input{
 		{LiteralInt(1), LiteralInt(2), LiteralInt(1), LiteralNull(&IntegerType{})},
 		{LiteralFloat(1), LiteralFloat(2), LiteralFloat(1), LiteralNull(&FloatType{})},
+		{LiteralBigInt(1), LiteralBigInt(2), LiteralBigInt(1), LiteralNull(&BigIntType{})},
 		{LiteralLong(1), LiteralLong(2), LiteralLong(1), LiteralNull(&LongType{})},
 		{LiteralShort(1), LiteralShort(2), LiteralShort(1), LiteralNull(&ShortType{})},
 		{LiteralDouble(1), LiteralDouble(2), LiteralDouble(1), LiteralNull(&DoubleType{})},

--- a/types/expr_column.go
+++ b/types/expr_column.go
@@ -19,8 +19,10 @@ func NewColumn(name string, t DataType) *Column {
 	switch t.(type) {
 	case *IntegerType:
 		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetInt(name) }
+	case *BigIntType:
+		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetBigInt64(name) }
 	case *LongType:
-		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetInt64(name) }
+		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetLongInt64(name) }
 	case *ByteType:
 		col.nullSafeEval = func(r RowRecord) (any, error) { return r.GetByte(name) }
 	case *ShortType:

--- a/types/expr_literal.go
+++ b/types/expr_literal.go
@@ -63,6 +63,10 @@ func LiteralFloat(f float32) *Literal {
 	return &Literal{Value: f, Type: &FloatType{}}
 }
 
+func LiteralBigInt(n int64) *Literal {
+	return &Literal{Value: n, Type: &BigIntType{}}
+}
+
 func LiteralLong(n int64) *Literal {
 	return &Literal{Value: n, Type: &LongType{}}
 }

--- a/types/expr_literal_test.go
+++ b/types/expr_literal_test.go
@@ -17,6 +17,7 @@ func TestLiteral(t *testing.T) {
 	testLiteral(LiteralDouble(float64(1.0)), float64(1.0), t)
 	testLiteral(LiteralInt(5), 5, t)
 	testLiteral(LiteralLong(int64(10)), int64(10), t)
+	testLiteral(LiteralBigInt(int64(10)), int64(10), t)
 
 	testLiteral(LiteralNull(&BooleanType{}), nil, t)
 	testLiteral(LiteralNull(&IntegerType{}), nil, t)

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -13,7 +13,8 @@ type RowRecord interface {
 	IsNullAt(fieldName string) (bool, error)
 
 	GetInt(fieldName string) (int, error)
-	GetInt64(fieldName string) (int64, error)
+	GetBigInt64(fieldName string) (int64, error)
+	GetLongInt64(fieldName string) (int64, error)
 	GetByte(fieldName string) (int8, error)
 	GetShort(fieldName string) (int16, error)
 	GetBoolean(fieldName string) (bool, error)

--- a/types/type_parser.go
+++ b/types/type_parser.go
@@ -11,8 +11,8 @@ import (
 )
 
 var nonDecimalTypes []DataType = []DataType{
-	&BinaryType{}, &BooleanType{}, &ByteType{}, &DateType{}, &DoubleType{},
-	&FloatType{}, &IntegerType{}, &LongType{}, &NullType{}, &ShortType{}, &StringType{}, &TimestampType{},
+	&BinaryType{}, &BooleanType{}, &ByteType{}, &DateType{}, &DoubleType{}, &LongType{},
+	&FloatType{}, &IntegerType{}, &BigIntType{}, &NullType{}, &ShortType{}, &StringType{}, &TimestampType{},
 }
 
 var nonDecimalNameToType map[string]DataType = make(map[string]DataType)

--- a/types/type_parser_test.go
+++ b/types/type_parser_test.go
@@ -63,6 +63,7 @@ func TestDataTypeSerde(t *testing.T) {
 	check(&ByteType{})
 	check(&ShortType{})
 	check(&IntegerType{})
+	check(&BigIntType{})
 	check(&LongType{})
 	check(&FloatType{})
 	check(&DoubleType{})

--- a/types/type_primitives.go
+++ b/types/type_primitives.go
@@ -64,11 +64,18 @@ func (i *IntegerType) Name() string {
 	return "integer"
 }
 
+type BigIntType struct {
+}
+
+func (l *BigIntType) Name() string {
+	return "bigint"
+}
+
 type LongType struct {
 }
 
 func (l *LongType) Name() string {
-	return "bigint"
+	return "long"
 }
 
 type NullType struct {


### PR DESCRIPTION
Currently, the existing code recognizes the `bigint` data type and it is mapped to the `LongType` struct, yet the `long` data type isn't mapped at all.
This PR presents the `BigInt` struct that differentiates between `bigint` and `long` (each mapped to the respective struct).
The importance of this change is to be able to parse Delta Lake [schema](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#schema-serialization-format) that includes the `long` type, for example:
```json
{"metaData":{
	"configuration":{
	},
	"createdTime":1699198265004,
	"description":"",
	"format": {
		"options":{},"provider":"parquet"
	},
	"id":"3688231a-f0c8-4d70-9653-d0d008d34fa5",
	"name":"",
	"partitionColumns":[],
	"schemaString":
		"{\"type\":\"struct\",\"fields\":[{\"name\":\"ID\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"Name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"Country\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}"}}
```

## NOTICE
I would clarify that I didn't see any type that is called `bigint` in the [Delta Lake protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md), yet I keep it so that existing code that relies on this type won't fail.