### PR TITLE
hotfix: feature-aware protocol read check for table-features protocol

### DIFF
--- a/conflict_checker.go
+++ b/conflict_checker.go
@@ -242,9 +242,36 @@ func (c *conflictChecker) checkForUpdatedApplicationTransactionIdsThatCurrentTxn
 	return nil
 }
 
+// supportedReaderFeatures lists the reader features the exporter can handle correctly.
+// For protocol 3/7 tables, we check the explicit readerFeatures list instead of the
+// version number — a table with minReaderVersion=3 but empty readerFeatures is safe
+// to read (e.g. after DROP FEATURE deletionVectors where minReaderVersion stays at 3).
+var supportedReaderFeatures = map[string]bool{
+	"timestampNtz":         true,
+	"typeWidening":         true,
+	"typeWidening-preview": true,
+	"variantType":          true,
+	"rowTracking":          true,
+}
+
 func assertProtocolRead(protocol *action.Protocol) error {
-	if protocol != nil && action.ReaderVersion < protocol.MinReaderVersion {
-		return errno.InvalidProtocolVersionError()
+	if protocol == nil {
+		return nil
+	}
+	// Legacy protocol (pre table-features): use version number as before.
+	if protocol.MinReaderVersion < 3 {
+		if action.ReaderVersion < protocol.MinReaderVersion {
+			return errno.InvalidProtocolVersionError()
+		}
+		return nil
+	}
+	// Protocol 3/7 (table features mode): check the explicit readerFeatures list.
+	// The version number alone is not sufficient — a table may have minReaderVersion=3
+	// with an empty readerFeatures list (e.g. after DROP FEATURE deletionVectors).
+	for _, feature := range protocol.ReaderFeatures {
+		if !supportedReaderFeatures[feature] {
+			return errno.UnsupportedReaderFeatureError(feature)
+		}
 	}
 	return nil
 }

--- a/errno/errors.go
+++ b/errno/errors.go
@@ -51,6 +51,10 @@ func InvalidProtocolVersionError() error {
 	return eris.New("invalid protocol version")
 }
 
+func UnsupportedReaderFeatureError(feature string) error {
+	return eris.New(fmt.Sprintf("unsupported reader feature: %s", feature))
+}
+
 func IllegalStateError(msg string) error {
 	return eris.Wrap(ErrIllegalState, msg)
 }

--- a/protocol_compat_test.go
+++ b/protocol_compat_test.go
@@ -51,3 +51,41 @@ func TestAssertProtocolRead_NilProtocol_Passes(t *testing.T) {
 	err := assertProtocolRead(nil)
 	assert.NoError(t, err)
 }
+
+// Protocol 3/7 with empty readerFeatures — the exact state after
+// DROP FEATURE deletionVectors when other writerFeatures remain.
+// minReaderVersion stays 3 but there are no actual reader requirements.
+func TestAssertProtocolRead_V3EmptyReaderFeatures_Passes(t *testing.T) {
+	p := &action.Protocol{
+		MinReaderVersion: 3,
+		MinWriterVersion: 7,
+		ReaderFeatures:   []string{},
+		WriterFeatures:   []string{"changeDataFeed", "invariants"},
+	}
+	err := assertProtocolRead(p)
+	assert.NoError(t, err)
+}
+
+// Protocol 3/7 with deletionVectors still in readerFeatures — must be blocked.
+func TestAssertProtocolRead_V3DeletionVectors_Rejected(t *testing.T) {
+	p := &action.Protocol{
+		MinReaderVersion: 3,
+		MinWriterVersion: 7,
+		ReaderFeatures:   []string{"deletionVectors"},
+		WriterFeatures:   []string{"deletionVectors", "changeDataFeed"},
+	}
+	err := assertProtocolRead(p)
+	assert.Error(t, err)
+}
+
+// Protocol 3/7 with only supported reader features — passes.
+func TestAssertProtocolRead_V3SupportedReaderFeatures_Passes(t *testing.T) {
+	p := &action.Protocol{
+		MinReaderVersion: 3,
+		MinWriterVersion: 7,
+		ReaderFeatures:   []string{"timestampNtz", "rowTracking"},
+		WriterFeatures:   []string{"rowTracking"},
+	}
+	err := assertProtocolRead(p)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
For tables at protocol 3/7 (table features mode), check the explicit readerFeatures list instead of the version number. A table may have minReaderVersion=3 with an empty readerFeatures list — e.g. after DROP FEATURE deletionVectors where minReaderVersion stays at 3 because other writerFeatures remain. The version number check incorrectly blocks these tables even though there are no actual reader requirements.

For legacy protocol (minReaderVersion < 3), keep the existing version number check unchanged.